### PR TITLE
Use a template literal to expand error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ captureExit.captureExit();
 
 // Open AnyBar (OSX only)
 exec('open --hide --background -a AnyBar', (error, stdout, stderror) => {
-  if (error) console.error('exec error: ${error}');
+  if (error) console.error(`exec error: ${error}`);
 });
 
 // Pulse


### PR DESCRIPTION
Current error logging uses a traditional string, so errors are reported as, `exec error: ${error}` instead of expanding the error message, like so:

```
exec error: Error: Command failed: open --hide --background -a AnyBar
Unable to find application named 'AnyBar'
```