### PR TITLE
Revert "Greenkeeper/initial"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ember-cli-anybar
 ==============================================================================
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/dollarshaveclub/ember-cli-anybar.svg)](https://greenkeeper.io/)
-
 A _non-intrusive_ build notification system built atop [AnyBar](https://github.com/tonsky/AnyBar).
 
 Installation


### PR DESCRIPTION
Reverts dollarshaveclub/ember-cli-anybar#24

Greenkeeper will not be enabled if you rebase/merge master into the greenkeeper branch. I did so to fix merge conflicts. Reverting this and disabling/re-enabling greenkeeper to start from scratch.